### PR TITLE
Implement IP binding by adding the HTTP_IP variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Use `1` for stable v1.Y.Z releases and `latest` for bleeding/unstable releases.
 ### Environment Variables
 
 - `RUST_LOG` (defaults to `info`): The log level used by the console/STDOUT. Set to `debug` so show HTTP requests and `trace` to show extensive debugging info.
+- `HTTP_IP` (defaults to `::`): The HTTP server will listen on this IP. Set to `127.0.0.1` or `::1` to only allow local access. 
 - `HTTP_PORT` (defaults to `9995`): The HTTP server port.
 - `HTTP_PATH` (defaults to `nut`): The HTTP server metrics path. You may want to set it to `/metrics` on new setups to avoid extra Prometheus configuration (not changed here due to compatibility).
 - `PRINT_METRICS_AND_EXIT` (defaults to `false`): Print a Markdown-formatted table consisting of all metrics and then immediately exit. Used mainly for generating documentation.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Use `1` for stable v1.Y.Z releases and `latest` for bleeding/unstable releases.
 ### Environment Variables
 
 - `RUST_LOG` (defaults to `info`): The log level used by the console/STDOUT. Set to `debug` so show HTTP requests and `trace` to show extensive debugging info.
-- `HTTP_IP` (defaults to `::`): The HTTP server will listen on this IP. Set to `127.0.0.1` or `::1` to only allow local access. 
+- `HTTP_ADDRESS` (defaults to `::`): The HTTP server will listen on this IP. Set to `127.0.0.1` or `::1` to only allow local access. 
 - `HTTP_PORT` (defaults to `9995`): The HTTP server port.
 - `HTTP_PATH` (defaults to `nut`): The HTTP server metrics path. You may want to set it to `/metrics` on new setups to avoid extra Prometheus configuration (not changed here due to compatibility).
 - `PRINT_METRICS_AND_EXIT` (defaults to `false`): Print a Markdown-formatted table consisting of all metrics and then immediately exit. Used mainly for generating documentation.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,15 @@
+use std::net::{IpAddr, Ipv6Addr};
+
 #[derive(Debug, Clone)]
 pub struct Config {
+    pub http_ip: IpAddr,
     pub http_port: u16,
     pub http_path: String,
     pub print_metrics_and_exit: bool,
 }
 
 impl Config {
+    const DEFAULT_HTTP_IP: IpAddr = IpAddr::V6(Ipv6Addr::UNSPECIFIED);
     const DEFAULT_HTTP_PORT: u16 = 9995;
     const DEFAULT_HTTP_PATH: &'static str = "/nut";
     const DEFAULT_PRINT_METRICS_AND_EXIT: bool = false;
@@ -13,10 +17,18 @@ impl Config {
 
 pub fn read_config() -> Config {
     let mut config = Config {
+        http_ip: Config::DEFAULT_HTTP_IP,
         http_port: Config::DEFAULT_HTTP_PORT,
         http_path: Config::DEFAULT_HTTP_PATH.to_owned(),
         print_metrics_and_exit: Config::DEFAULT_PRINT_METRICS_AND_EXIT,
     };
+
+
+    if let Ok(http_ip_str) = std::env::var("HTTP_IP") {
+        if let Ok(http_ip) = http_ip_str.parse::<IpAddr>() {
+            config.http_ip = http_ip;
+        }
+    }
 
     if let Ok(http_port_str) = std::env::var("HTTP_PORT") {
         if let Ok(http_port) = http_port_str.parse::<u16>() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,14 +2,14 @@ use std::net::{IpAddr, Ipv6Addr};
 
 #[derive(Debug, Clone)]
 pub struct Config {
-    pub http_ip: IpAddr,
+    pub http_address: IpAddr,
     pub http_port: u16,
     pub http_path: String,
     pub print_metrics_and_exit: bool,
 }
 
 impl Config {
-    const DEFAULT_HTTP_IP: IpAddr = IpAddr::V6(Ipv6Addr::UNSPECIFIED);
+    const DEFAULT_HTTP_ADDRESS: IpAddr = IpAddr::V6(Ipv6Addr::UNSPECIFIED);
     const DEFAULT_HTTP_PORT: u16 = 9995;
     const DEFAULT_HTTP_PATH: &'static str = "/nut";
     const DEFAULT_PRINT_METRICS_AND_EXIT: bool = false;
@@ -17,16 +17,16 @@ impl Config {
 
 pub fn read_config() -> Config {
     let mut config = Config {
-        http_ip: Config::DEFAULT_HTTP_IP,
+        http_address: Config::DEFAULT_HTTP_ADDRESS,
         http_port: Config::DEFAULT_HTTP_PORT,
         http_path: Config::DEFAULT_HTTP_PATH.to_owned(),
         print_metrics_and_exit: Config::DEFAULT_PRINT_METRICS_AND_EXIT,
     };
 
 
-    if let Ok(http_ip_str) = std::env::var("HTTP_IP") {
-        if let Ok(http_ip) = http_ip_str.parse::<IpAddr>() {
-            config.http_ip = http_ip;
+    if let Ok(http_address_str) = std::env::var("HTTP_ADDRESS") {
+        if let Ok(http_address) = http_address_str.parse::<IpAddr>() {
+            config.http_address = http_address;
         }
     }
 

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::convert::Infallible;
-use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+use std::net::{SocketAddr};
 
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use hyper::service::{make_service_fn, service_fn};
@@ -12,7 +12,7 @@ use crate::config::Config;
 use crate::nut_client::scrape_nut_to_openmetrics;
 
 pub async fn run_server(config: Config) {
-    let endpoint = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), config.http_port);
+    let endpoint = SocketAddr::new(config.http_ip, config.http_port);
     let service_maker = make_service_fn(move |conn:  &AddrStream| {
         let config = config.clone();
         let remote_addr = conn.remote_addr();

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -12,7 +12,7 @@ use crate::config::Config;
 use crate::nut_client::scrape_nut_to_openmetrics;
 
 pub async fn run_server(config: Config) {
-    let endpoint = SocketAddr::new(config.http_ip, config.http_port);
+    let endpoint = SocketAddr::new(config.http_address, config.http_port);
     let service_maker = make_service_fn(move |conn:  &AddrStream| {
         let config = config.clone();
         let remote_addr = conn.remote_addr();


### PR DESCRIPTION
By default, the exporter will bind to all IP (``::``).
Add the ``HTTP_IP`` variable to be able to listen on a specific IP.

If the ``HTTP_IP`` variable does not contain a valid IP address, it will
be ignored and the daemon will listen on ``::``

This variable accept valid IPv4 and IPv6 address.

Validation:
* Running the service without ``HTTP_IP`` set: 
```
01:40:07 [nico@khany:~/prometheus-nut-exporter] # export RUST_LOG=debug
01:40:16 [nico@khany:~/prometheus-nut-exporter] # ./target/release/prometheus-nut-exporter
[2022-01-08T01:40:20Z INFO  prometheus_nut_exporter::http_server] Listening on http://[::1]:9995
```
* Running the service with HTTP_IP set to ``127.0.0.1``:
```
01:40:21 [nico@khany:~/prometheus-nut-exporter] 130 # export HTTP_IP=127.0.0.1
01:40:25 [nico@khany:~/prometheus-nut-exporter] # ./target/release/prometheus-nut-exporter
[2022-01-08T01:40:27Z INFO  prometheus_nut_exporter::http_server] Listening on http://127.0.0.1:9995
```
* Running the service with HTTP_IP set to an invalid value; same behaviour as the default:
```
01:40:28 [nico@khany:~/prometheus-nut-exporter] 130 # export HTTP_IP=a.b.c.d
01:40:33 [nico@khany:~/prometheus-nut-exporter] # ./target/release/prometheus-nut-exporter
[2022-01-08T01:40:34Z INFO  prometheus_nut_exporter::http_server] Listening on http://[::]:9995
```
* Running the service with HTTP_IP set to ``::1``:
```
01:40:35 [nico@khany:~/prometheus-nut-exporter] 130 # export HTTP_IP=::1
01:40:39 [nico@khany:~/prometheus-nut-exporter] # ./target/release/prometheus-nut-exporter
[2022-01-08T01:40:41Z INFO  prometheus_nut_exporter::http_server] Listening on http://[::1]:9995
```

Please note I do not know rust so I just followed the style of the current code and the error message from the compiler.