### PR TITLE
Add option to calculate a UPS power value when none available - "UPS_POWER_FROM_LOAD_PERCENTAGE"

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Use e.g. `1` for stable v1.y.z releases and `latest` for bleeding/dev/unstable r
 - `HTTP_PORT` (defaults to `9995`): The HTTP server port.
 - `HTTP_PATH` (defaults to `nut`): The HTTP server metrics path. You may want to set it to `/metrics` on new setups to avoid extra Prometheus configuration (not changed here due to compatibility).
 - `PRINT_METRICS_AND_EXIT` (defaults to `false`): Print a Markdown-formatted table consisting of all metrics and then immediately exit. Used mainly for generating documentation.
+- `UPS_POWER_FROM_LOAD_PERCENTAGE` (defaults to `false`): when set to `true` and a value for `ups.power` is not available from a UPS, an approximate value will be calculated for the metric `nut_power_watts` (Apparent Power). Useful for UPS units that do not report the load in Watts, like some CyberPower units. The calculation will be: `( ups.load / 100.00 ) * ups.realpower.nominal`. 
 
 ## Metrics
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,7 +34,6 @@ pub fn read_config() -> Config {
             config.http_address = http_address;
         }
     }
-    
     if let Ok(http_port_str) = std::env::var("HTTP_PORT") {
         if let Ok(http_port) = http_port_str.parse::<u16>() {
             config.http_port = http_port;
@@ -50,8 +49,6 @@ pub fn read_config() -> Config {
             config.print_metrics_and_exit = print_metrics_and_exit;
         }
     }
-
-    // Establish user settings for how metrics are generated
     if let Ok(ups_power_from_load_percentage_str) = std::env::var("UPS_POWER_FROM_LOAD_PERCENTAGE") {
         if let Ok(ups_power_from_load_percentage) = ups_power_from_load_percentage_str.parse::<bool>() {
             config.ups_power_from_load_percentage = ups_power_from_load_percentage;

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ pub struct Config {
     pub http_port: u16,
     pub http_path: String,
     pub print_metrics_and_exit: bool,
+    pub ups_power_from_load_percentage: bool,
 }
 
 impl Config {
@@ -16,6 +17,7 @@ impl Config {
     const DEFAULT_HTTP_PORT: u16 = 9995;
     const DEFAULT_HTTP_PATH: &'static str = "/nut";
     const DEFAULT_PRINT_METRICS_AND_EXIT: bool = false;
+    const DEFAULT_UPS_POWER_FROM_LOAD_PERCENTAGE: bool = false;
 }
 
 pub fn read_config() -> Config {
@@ -24,6 +26,7 @@ pub fn read_config() -> Config {
         http_port: Config::DEFAULT_HTTP_PORT,
         http_path: Config::DEFAULT_HTTP_PATH.to_owned(),
         print_metrics_and_exit: Config::DEFAULT_PRINT_METRICS_AND_EXIT,
+        ups_power_from_load_percentage: Config::DEFAULT_UPS_POWER_FROM_LOAD_PERCENTAGE,
     };
 
     if let Ok(http_address_str) = std::env::var("HTTP_ADDRESS") {
@@ -31,7 +34,7 @@ pub fn read_config() -> Config {
             config.http_address = http_address;
         }
     }
-
+    
     if let Ok(http_port_str) = std::env::var("HTTP_PORT") {
         if let Ok(http_port) = http_port_str.parse::<u16>() {
             config.http_port = http_port;
@@ -45,6 +48,13 @@ pub fn read_config() -> Config {
     if let Ok(print_metrics_and_exit_str) = std::env::var("PRINT_METRICS_AND_EXIT") {
         if let Ok(print_metrics_and_exit) = print_metrics_and_exit_str.parse::<bool>() {
             config.print_metrics_and_exit = print_metrics_and_exit;
+        }
+    }
+
+    // Establish user settings for how metrics are generated
+    if let Ok(ups_power_from_load_percentage_str) = std::env::var("UPS_POWER_FROM_LOAD_PERCENTAGE") {
+        if let Ok(ups_power_from_load_percentage) = ups_power_from_load_percentage_str.parse::<bool>() {
+            config.ups_power_from_load_percentage = ups_power_from_load_percentage;
         }
     }
 

--- a/src/nut_client.rs
+++ b/src/nut_client.rs
@@ -133,17 +133,15 @@ async fn override_nut_values(vars: &mut HashMap<String, String>) {
     // For UPS systems where ups.power is not available, but ups.load and ups.realpower.nominal are.
     // Provide a calculated value for ups.power with the following algorithm:
     //     power (W) = ( load(%) / 100.00 ) * nominal power (W)
-    if config.ups_power_from_load_percentage {
-        if !( vars.contains_key("ups.power") ) && vars.contains_key("ups.load") && vars.contains_key("ups.realpower.nominal") {
-            if let (Ok(load), Ok(nominal_power)) = (
-                vars.get("ups.load").unwrap().parse::<f64>(),
-                vars.get("ups.realpower.nominal").unwrap().parse::<f64>(),
-            ) {
-                let calculated_power = (load / 100.0) * nominal_power;
-                vars.insert(String::from("ups.power"), calculated_power.to_string());
-            } else {
-                log::error!("Unable to parse ups.load or ups.realpower.nominal as floats, skipping calculation of ups.power from these values");
-            }
+    if config.ups_power_from_load_percentage && !( vars.contains_key("ups.power") ) && vars.contains_key("ups.load") && vars.contains_key("ups.realpower.nominal") {
+        if let (Ok(load), Ok(nominal_power)) = (
+            vars.get("ups.load").unwrap().parse::<f64>(),
+            vars.get("ups.realpower.nominal").unwrap().parse::<f64>(),
+        ) {
+            let calculated_power = (load / 100.0) * nominal_power;
+            vars.insert(String::from("ups.power"), calculated_power.to_string());
+        } else {
+            log::error!("Unable to parse ups.load or ups.realpower.nominal as floats, skipping calculation of ups.power from these values");
         }
     }
 }


### PR DESCRIPTION
This works on my setup with a CyberPower OR600ERM1U UPS.

I'd love to run tests and poked around in `manage/` but I couldn't figure out how to get that going - if you have any pointers I'd be happy to try again

My `upsc` output pretty much matches the CyberPower example in `example-data/LIST-VAR-4.txt`.